### PR TITLE
adding 404 response on deleteIssue

### DIFF
--- a/src/controllers/issuesController.js
+++ b/src/controllers/issuesController.js
@@ -69,6 +69,7 @@ const deleteIssue = async (req, res) => {
     const { id } = req.params;
     const deletedIssue = await Issue.findByIdAndDelete(id);
     
+    // if no issue found with the id, return this
     if (!deletedIssue) {
       return res.status(404).json(`No issue with id ${id}`);
     }

--- a/src/controllers/issuesController.js
+++ b/src/controllers/issuesController.js
@@ -67,7 +67,11 @@ const updateIssue = async (req, res) => {
 const deleteIssue = async (req, res) => {
   try {
     const { id } = req.params;
-    await Issue.findByIdAndDelete(id);
+    const deletedIssue = await Issue.findByIdAndDelete(id);
+    
+    if (!deletedIssue) {
+      return res.status(404).json(`No issue with id ${id}`);
+    }
 
     res.status(200).json(`Issue has been deleted!`);
   } catch (error) {


### PR DESCRIPTION
When attempting to delete an id that does not exist, the service would say it was deleted successfully instead of returning a 404 error. 